### PR TITLE
chore: migrate to cli-table3

### DIFF
--- a/lib/utils/helpers.js
+++ b/lib/utils/helpers.js
@@ -4,7 +4,7 @@
 const fs = require('fs')
 const path = require('path')
 const moment = require('moment')
-const Table = require('cli-table2')
+const Table = require('cli-table3')
 const expandHomeDir = require('expand-home-dir')
 
 // ours

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bluebird": "3.5.1",
     "caporal": "0.10.0",
     "chalk": "2.4.1",
-    "cli-table2": "0.2.0",
+    "cli-table3": "0.5.0",
     "expand-home-dir": "0.0.3",
     "fs-extra": "6.0.1",
     "jsonfile": "4.0.0",


### PR DESCRIPTION
Needs a new `npm install` after the merge to update the lockfile.